### PR TITLE
Warnings not good at this time

### DIFF
--- a/PostSharp.Community.DeepSerializable.Tests.Dependency/Class1.cs
+++ b/PostSharp.Community.DeepSerializable.Tests.Dependency/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace PostSharp.Community.DeepSerializable.Tests.Dependency
+{
+    public class Outsider
+    {
+    }
+}

--- a/PostSharp.Community.DeepSerializable.Tests.Dependency/PostSharp.Community.DeepSerializable.Tests.Dependency.csproj
+++ b/PostSharp.Community.DeepSerializable.Tests.Dependency/PostSharp.Community.DeepSerializable.Tests.Dependency.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+</Project>

--- a/PostSharp.Community.DeepSerializable.Tests/DependencyTests.cs
+++ b/PostSharp.Community.DeepSerializable.Tests/DependencyTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using PostSharp.Community.DeepSerializable.Tests.Data;
+using PostSharp.Community.DeepSerializable.Tests.Dependency;
+using Xunit;
+
+namespace PostSharp.Community.DeepSerializable.Tests
+{
+    public class DependencyTests
+    {
+        [Fact]
+        public void OutsiderNotSerializable()
+        {
+            BinaryFormatter bf = new BinaryFormatter();
+            MemoryStream serializationStream = new MemoryStream();
+            Assert.Throws<SerializationException>(() =>
+            {
+                bf.Serialize(serializationStream, new ContainsOutsider());
+                serializationStream.Close();
+            });
+        }
+
+        [Fact]
+        public void NonSerializedOutsiderIsOk()
+        {
+            BinaryFormatter bf = new BinaryFormatter();
+            MemoryStream serializationStream = new MemoryStream();
+            bf.Serialize(serializationStream, new ContainsNonSerializedOutsider());
+            serializationStream.Close();
+        }
+        
+    }
+
+    [DeepSerializable]
+    public class ContainsOutsider
+    {
+        public GameState GameState { get; set; } = new GameState();
+        public Outsider Outsider { get; set; } = new Outsider();
+    }
+    [DeepSerializable]
+    public class ContainsNonSerializedOutsider
+    {
+        public GameState GameState { get; set; } = new GameState();
+        [field:NonSerialized]
+        public Outsider Outsider { get; set; } = new Outsider();
+    }
+}

--- a/PostSharp.Community.DeepSerializable.Tests/PostSharp.Community.DeepSerializable.Tests.csproj
+++ b/PostSharp.Community.DeepSerializable.Tests/PostSharp.Community.DeepSerializable.Tests.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\PostSharp.Community.DeepSerializable.Tests.Dependency\PostSharp.Community.DeepSerializable.Tests.Dependency.csproj" />
       <ProjectReference Include="..\PostSharp.Community.DeepSerializable.Weaver\PostSharp.Community.DeepSerializable.Weaver.csproj" />
       <ProjectReference Include="..\PostSharp.Community.DeepSerializable\PostSharp.Community.DeepSerializable.csproj" />
     </ItemGroup>

--- a/PostSharp.Community.DeepSerializable.Weaver/DeepSerializableTask.cs
+++ b/PostSharp.Community.DeepSerializable.Weaver/DeepSerializableTask.cs
@@ -55,12 +55,12 @@ namespace PostSharp.Community.DeepSerializable.Weaver
 
         private void IdentifyAndMakeSerializableRecursively(ITypeSignature type, MessageLocation location)
         {
-
             switch (type.TypeSignatureElementKind)
             {
                 case TypeSignatureElementKind.Intrinsic:
                     // This works automatically for most, but:
-                    // TODO: have an error for object, IntPtr.
+                    // Consider an error for object, IntPtr, but also consider that those fields may be marked as [NonSerialized].
+                    // In the future, we might want to exclude such fields.
                     break;
 
                 case TypeSignatureElementKind.TypeDef:
@@ -106,8 +106,15 @@ namespace PostSharp.Community.DeepSerializable.Weaver
         {
             if (!IsSerializable(type))
             {
-                 Message.Write(location, SeverityType.Warning, "DSER001",
-                     "The type {0} is not serializable, but it's not in the same assembly so I cannot modify it.", type);
+                // This does not work properly on .NET Core.
+                // PostSharp has difficulty understanding that some classes in .NET Core are serializable.
+                
+                // In addition, some fields are not meant to be serialized so it's better not to emit a warning for those
+                // as well.
+                
+                // Message.Write(location, SeverityType.Warning, "DSER001",
+                //     "A type (" + type.Name +
+                //     ") is not serializable, but it's not in the same assembly so I cannot modify it.");
             }
         }
 

--- a/PostSharp.Community.DeepSerializable.nuspec
+++ b/PostSharp.Community.DeepSerializable.nuspec
@@ -2,15 +2,14 @@
 <package>
   <metadata>
     <id>PostSharp.Community.DeepSerializable</id>
-    <version>1.1-preview</version>
+    <version>1.2-preview</version>
     <title>PostSharp.Community.DeepSerializable</title>
     <authors>PostSharp Technologies</authors>
     <owners>PostSharp Technologies</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
-    <projectUrl>https://github.com/postsharp</projectUrl>
+    <projectUrl>https://github.com/postsharp/PostSharp.Community.DeepSerializable</projectUrl>
     <icon>icon.png</icon>
-    <iconUrl>https://cdn2.iconfinder.com/data/icons/pictograms-vol-1/400/square_brackets-512.png</iconUrl>
     <description>A class annotated with [DeepSerializable] and all of its fields, recursively, are marked as serializable.</description>
     <releaseNotes>Initial release.</releaseNotes>
     <copyright>PostSharp Technologies</copyright>

--- a/PostSharp.Community.DeepSerializable.sln
+++ b/PostSharp.Community.DeepSerializable.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PostSharp.Community.DeepSer
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PostSharp.Community.DeepSerializable.Tests", "PostSharp.Community.DeepSerializable.Tests\PostSharp.Community.DeepSerializable.Tests.csproj", "{F50CA89A-7A52-4934-B3FC-2FFB69813421}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PostSharp.Community.DeepSerializable.Tests.Dependency", "PostSharp.Community.DeepSerializable.Tests.Dependency\PostSharp.Community.DeepSerializable.Tests.Dependency.csproj", "{933DE6F8-55EC-4CA4-A85E-F1DCD0AF8FA7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{F50CA89A-7A52-4934-B3FC-2FFB69813421}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F50CA89A-7A52-4934-B3FC-2FFB69813421}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F50CA89A-7A52-4934-B3FC-2FFB69813421}.Release|Any CPU.Build.0 = Release|Any CPU
+		{933DE6F8-55EC-4CA4-A85E-F1DCD0AF8FA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{933DE6F8-55EC-4CA4-A85E-F1DCD0AF8FA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{933DE6F8-55EC-4CA4-A85E-F1DCD0AF8FA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{933DE6F8-55EC-4CA4-A85E-F1DCD0AF8FA7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ Add the `[PostSharp.Community.DeepSerializable.DeepSerializableAttribute]` to th
 
 #### Limitations
 
-* DeepSerializable works in the current project. If a deep-serializable object has a dependency to
-  a type declared in a different assembly, we will emit an error if this type is not serializable.
+* DeepSerializable works in the current project. If a deep-serializable object has a dependency on
+  a type declared in a different assembly, it will not be fully serializable.
 
-* DeepSerializable won't make derived types serializable by default.
+* Even if you make a base class deep-serializable, subclasses that inherit from that base class won't 
+be serializable unless they're also annotated with `[Serializable]` or `[DeepSerializable]`.
 
 
 #### Copyright notices


### PR DESCRIPTION
Warnings aren't possible yet because of NonSerialized and because of type forwarding and serialization in .NET Core.